### PR TITLE
fix: 404 links

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ Watch the following demo for a 10-minute introduction making a contribution:
 <br>
 The [presentation slides](https://hturner.github.io/contributing-demo/) are available in HTML format - press `S` to view with speaker notes (the video text). 
 
-The demo introduces a basic workflow for simple fixes. For more complex work on internal R functions or compiled code (e.g. involving the C code underlying much of base R), it will be necessary to build R to develop and test your patch. The R Development Guide provides more information on [building R from source](https://contributor.r-project.org/rdevguide/GetStart.html) and [the lifecycle of a patch](https://contributor.r-project.org/rdevguide/FixBug.html).
+The demo introduces a basic workflow for simple fixes. For more complex work on internal R functions or compiled code (e.g. involving the C code underlying much of base R), it will be necessary to build R to develop and test your patch. The R Development Guide provides more information on [building R from source](https://contributor.r-project.org/rdevguide/chapters/getting_started.html) and [the lifecycle of a patch](https://contributor.r-project.org/rdevguide/chapters/lifecycle_of_a_patch.html).
 
 ## About 
 

--- a/index.md
+++ b/index.md
@@ -23,4 +23,4 @@ The demo introduces a basic workflow for simple fixes. For more complex work on 
 
 ## About 
 
-This site is maintained by the [R Contribution Working Group](working-group), which is working on initiatives to encourage wider contribution to R core. The working group is open to new members ([more information](working-group)). 
+This site is maintained by the [R Contribution Working Group](working-group), which is working on initiatives to encourage wider contribution to R core. The working group is open to new members ([more information](working-group)). You can report issues about this website on the [r-devel.github.io](https://github.com/r-devel/r-devel.github.io) repository.


### PR DESCRIPTION
Hi. This fixes two 404 links on the main page of https://contributor.r-project.org/